### PR TITLE
Fix base path of index.html in two_in_one_movie_player

### DIFF
--- a/two_in_one_movie_player/index.html
+++ b/two_in_one_movie_player/index.html
@@ -14,7 +14,7 @@
     This is a placeholder for base href that will be replaced by the value of
     the `--base-href` argument provided to `flutter build`.
   -->
-  <base href="/">
+  <base href="/two_in_one_movie_player/">
 
   <meta charset="UTF-8">
   <meta content="IE=Edge" http-equiv="X-UA-Compatible">


### PR DESCRIPTION
When you serve your Flutter web app in a different folder than the root, you have to adjust the base path. You may want to do this in your private repo in ./web/index.html that builds the files in this repo.